### PR TITLE
Perform update on startup

### DIFF
--- a/.config/term/root.rc
+++ b/.config/term/root.rc
@@ -8,8 +8,6 @@ TC_ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # TC_ENABLE_DEBUG_FLAG="true"
 . $TC_ROOT_DIR/helpers.rc.internal
 
-# TODO: check for update? If so, we might have to restart dotfiles!
-
 # Set the modules dir
 TC_MODULES_DIR=$TC_ROOT_DIR/../../modules
 
@@ -22,6 +20,10 @@ fi
 
 # Get the shell that is running this config
 TC_SHELL=$(detect_shell_type)
+
+# next, check for updates
+# If this finds an update, the whole session will be restarted!
+. $TC_ROOT_DIR/update.rc.internal
 
 # This space is reserved for order-dependent loading
 

--- a/.config/term/update.rc.internal
+++ b/.config/term/update.rc.internal
@@ -84,3 +84,8 @@ unset yn
 
 $(cd $TC_ROOT_DIR && git checkout --quiet main)
 $(cd $TC_ROOT_DIR && git pull --quiet --ff-only)
+
+
+# Restart the shell environment
+# Since we only do this at the start of the terminal, this should not be too drastic
+exec "$SHELL"


### PR DESCRIPTION
Update is no longer a "random" load/execute, but rather before any user-dependent startup script.
In addition, update now restarts the session, resulting in a "clean" start for dotfiles on update